### PR TITLE
Add Streamlit dashboard for S&P500 and economic indicators

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # sample-repo
-Git 練習用
+
+S&P500の推移、主要な経済指標、関連ニュースを確認できる簡易ダッシュボードです。
+
+## 使い方
+
+1. 依存パッケージをインストールします。
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. [NewsAPI](https://newsapi.org/) のAPIキーを取得し、環境変数 `NEWSAPI_KEY` に設定します。
+3. ダッシュボードを起動します。
+   ```bash
+   streamlit run dashboard.py
+   ```
+
+ダッシュボードでは直近1年のS&P500の終値、FREDから取得したCPIと失業率、NewsAPIによる関連ニュースを表示します。

--- a/dashboard.py
+++ b/dashboard.py
@@ -1,0 +1,51 @@
+import os
+from datetime import datetime, timedelta
+
+import pandas_datareader.data as web
+import requests
+import streamlit as st
+import yfinance as yf
+
+st.title("S&P 500 Dashboard")
+
+# Fetch S&P 500 data
+start = datetime.today() - timedelta(days=365)
+end = datetime.today()
+sp500 = yf.Ticker("^GSPC")
+data = sp500.history(start=start, end=end)
+st.subheader("S&P 500 Price")
+st.line_chart(data['Close'])
+
+# Economic indicators
+indicator_symbols = {
+    "Consumer Price Index": "CPIAUCSL",
+    "Unemployment Rate": "UNRATE",
+}
+for name, symbol in indicator_symbols.items():
+    try:
+        indicator = web.DataReader(symbol, "fred", start)
+        st.subheader(name)
+        st.line_chart(indicator)
+    except Exception as e:
+        st.warning(f"Failed to load {name}: {e}")
+
+# News section
+api_key = os.getenv("NEWSAPI_KEY")
+if api_key:
+    params = {
+        "q": "S&P 500",
+        "apiKey": api_key,
+        "language": "en",
+        "pageSize": 5,
+    }
+    response = requests.get("https://newsapi.org/v2/everything", params=params, timeout=10)
+    if response.ok:
+        articles = response.json().get("articles", [])
+        st.subheader("Latest News")
+        for article in articles:
+            st.markdown(f"**[{article['title']}]({article['url']})**")
+            st.write(article.get("description", ""))
+    else:
+        st.warning("Failed to load news")
+else:
+    st.info("Set NEWSAPI_KEY environment variable to display news.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+streamlit
+yfinance
+pandas
+pandas-datareader
+requests


### PR DESCRIPTION
## Summary
- implement Streamlit-based dashboard showing S&P 500 prices, CPI, unemployment, and related news
- add requirements.txt and usage instructions in README

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile dashboard.py`


------
https://chatgpt.com/codex/tasks/task_e_68a03a0c94388333a0b72966402c2771